### PR TITLE
Fix calendar data fetch path

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -130,6 +130,7 @@ main {
 }
 .day-cell.has-log {
   border-color: var(--primary);
+  background: rgba(59, 130, 246, 0.15);
 }
 .day-cell:hover:not(.disabled) {
   transform: translateY(-2px);

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -18,13 +18,13 @@ export default {
     return { dates: [], selectedLog: null }
   },
     created() {
-      fetch('./index.json')
+      fetch('./logs/index.json')
         .then(r => r.json())
         .then(d => { this.dates = d })
   },
   methods: {
     fetchLog(date) {
-      fetch(`./${date}.json`)
+      fetch(`./logs/${date}.json`)
         .then(r => r.json())
         .then(j => this.selectedLog = j)
     }

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -20,10 +20,10 @@ export default {
     return { logs: [], pageSize: 10 }
   },
     created() {
-      fetch('./index.json')
+      fetch('./logs/index.json')
         .then(r => r.json())
         .then(dates =>
-            Promise.all(dates.map(d => fetch(`./${d}.json`).then(r => r.json())))
+            Promise.all(dates.map(d => fetch(`./logs/${d}.json`).then(r => r.json())))
         )
         .then(arr => this.logs = arr)
   }


### PR DESCRIPTION
## Summary
- fetch log data from the correct `public/logs` directory
- highlight calendar days that have logs

## Testing
- `npm test --silent` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6872510f21b4833290e7a3d3eb183847