### PR TITLE
Fix relative paths for logs

### DIFF
--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -18,13 +18,15 @@ export default {
     return { dates: [], selectedLog: null }
   },
     created() {
-      fetch('/logs/index.json')
+      const base = import.meta.env.BASE_URL
+      fetch(`${base}logs/index.json`)
         .then(r => r.json())
         .then(d => { this.dates = d })
   },
   methods: {
     fetchLog(date) {
-      fetch(`/logs/${date}.json`)
+      const base = import.meta.env.BASE_URL
+      fetch(`${base}logs/${date}.json`)
         .then(r => r.json())
         .then(j => this.selectedLog = j)
     }

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -20,10 +20,11 @@ export default {
     return { logs: [], pageSize: 10 }
   },
     created() {
-      fetch('/logs/index.json')
+      const base = import.meta.env.BASE_URL
+      fetch(`${base}logs/index.json`)
         .then(r => r.json())
         .then(dates =>
-            Promise.all(dates.map(d => fetch(`/logs/${d}.json`).then(r => r.json())))
+            Promise.all(dates.map(d => fetch(`${base}logs/${d}.json`).then(r => r.json())))
         )
         .then(arr => this.logs = arr)
   }


### PR DESCRIPTION
## Summary
- adjust CalendarView to fetch logs relative to `import.meta.env.BASE_URL`
- update ListView to use the same base path when loading logs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687257072fd483329a8e1275204249d5