### PR TITLE
Fix root path display

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,6 @@ const routes = [
 ]
 
 export default createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
   plugins: [vue()],
-  base: './',
+  base: '/training-log-spa/',
   test: {
     globals: true,
     environment: 'jsdom'


### PR DESCRIPTION
## Summary
- set router history base to `import.meta.env.BASE_URL`
- set vite base to `/training-log-spa/`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68725f333cf08332bf8f5b1bc18e34ae