### PR TITLE
Fix 404 on refresh by using hash-based routing

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import CalendarView from '../views/CalendarView.vue'
 import ListView     from '../views/ListView.vue'
 
@@ -9,6 +9,6 @@ const routes = [
 ]
 
 export default createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes
 })


### PR DESCRIPTION
## Summary
- use `createWebHashHistory` for Vue Router

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726148144083328b2ca6fad80c36bb