### PR TITLE
Add log automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/training-log.yml
+++ b/.github/ISSUE_TEMPLATE/training-log.yml
@@ -1,0 +1,10 @@
+name: "Training Log"
+description: "Register a daily training log in JSON format"
+labels: ["training-log"]
+body:
+  - type: textarea
+    attributes:
+      label: "Training Log JSON"
+      description: "Paste the day's training log in JSON format"
+    validations:
+      required: true

--- a/.github/workflows/add-log.yml
+++ b/.github/workflows/add-log.yml
@@ -1,0 +1,28 @@
+name: Add or Update Training Log
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  add-log:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Update log files
+        env:
+          JSON_PAYLOAD: ${{ github.event.issue.body }}
+        run: node scripts/updateLog.js
+      - name: Commit changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          if ! git diff --quiet; then
+            git add public/logs
+            git commit -m "Update training log" && git push
+          fi

--- a/scripts/updateLog.js
+++ b/scripts/updateLog.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+
+function computeBench1RM(w, r) {
+  return w * r / 40 + w;
+}
+function computeBenchE1RM(w, r, rpe) {
+  return w * (r + 10 - rpe) / 40 + w;
+}
+function computeSd1RM(w, r) {
+  return w * r / 33.3 + w;
+}
+function computeSdE1RM(w, r, rpe) {
+  return w * (r + 10 - rpe) / 33.3 + w;
+}
+
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+const payload = process.env.JSON_PAYLOAD;
+if (!payload) {
+  console.error('JSON_PAYLOAD env var is required');
+  process.exit(1);
+}
+let data;
+try {
+  data = JSON.parse(payload);
+} catch (e) {
+  console.error('Invalid JSON payload');
+  throw e;
+}
+
+if (!data.date) {
+  console.error('date field is required');
+  process.exit(1);
+}
+
+// compute 1RM and e1RM
+for (const session of data.sessions || []) {
+  const type = session.type || '';
+  const isAccessory = type.includes('アクセサリー');
+  for (const set of session.sets || []) {
+    if (isAccessory) continue;
+    const w = set.weight;
+    const r = set.reps;
+    const rpe = set.rpe;
+    if (type.includes('ベンチ')) {
+      set['1RM'] = round2(computeBench1RM(w, r));
+      set.e1RM = round2(computeBenchE1RM(w, r, rpe));
+    } else {
+      set['1RM'] = round2(computeSd1RM(w, r));
+      set.e1RM = round2(computeSdE1RM(w, r, rpe));
+    }
+  }
+}
+
+const repoRoot = path.join(__dirname, '..');
+const logDir = path.join(repoRoot, 'public', 'logs');
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir, { recursive: true });
+}
+
+const filePath = path.join(logDir, `${data.date}.json`);
+fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+
+const indexPath = path.join(logDir, 'index.json');
+let index = [];
+if (fs.existsSync(indexPath)) {
+  index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+}
+if (!index.includes(data.date)) {
+  index.push(data.date);
+  index.sort();
+  fs.writeFileSync(indexPath, JSON.stringify(index, null, 2));
+}


### PR DESCRIPTION
## Summary
- add GitHub issue template to capture training log JSON
- create workflow triggered by issues to update log JSON files
- implement helper script to calculate `1RM` and `e1RM` and update logs

## Testing
- `npm install --silent` *(fails: internet disabled)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872654d723483329bd259e7f768a566