### PR TITLE
Display type tag in training details

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -185,6 +185,15 @@ main {
   margin-bottom: 0.5rem;
   color: var(--text);
 }
+.type-tag {
+  display: inline-block;
+  background: var(--primary-light);
+  color: var(--primary-dark);
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: var(--radius);
+  margin-left: 6px;
+}
 .session .table-wrapper {
   overflow-x: auto;
   margin-bottom: var(--spacing);

--- a/src/components/LogDetail.vue
+++ b/src/components/LogDetail.vue
@@ -18,6 +18,7 @@
       <h3 class="session-title">
         {{ session.lift }}
         <small v-if="session.variation">({{ session.variation }})</small>
+        <span v-if="session.type" class="type-tag">{{ session.type }}</span>
       </h3>
       <div class="table-wrapper">
         <table>

--- a/src/components/LogList.vue
+++ b/src/components/LogList.vue
@@ -13,7 +13,11 @@
       </div>
       <div class="details">
         <div v-for="session in log.sessions" :key="session.lift" class="session">
-          <h2>{{ session.lift }}<span v-if="session.variation"> ({{ session.variation }})</span></h2>
+          <h2>
+            {{ session.lift }}
+            <span v-if="session.variation"> ({{ session.variation }})</span>
+            <span v-if="session.type" class="type-tag">{{ session.type }}</span>
+          </h2>
           <div class="table-wrapper">
             <table>
               <tr>


### PR DESCRIPTION
## Summary
- display session type tag next to lift name in log detail
- display session type tag in log list view
- add `type-tag` styling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687265c5da4083329558fc2034a9e93c