### PR TITLE
Add tag styling for log meta info

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -171,6 +171,18 @@ main {
   color: var(--muted);
   margin-bottom: var(--spacing);
 }
+.meta span {
+  display: inline-block;
+  background: var(--primary-light);
+  color: var(--primary-dark);
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: var(--radius);
+  margin-right: 6px;
+}
+.meta span:last-child {
+  margin-right: 0;
+}
 .notes {
   font-style: italic;
   margin-bottom: var(--spacing);


### PR DESCRIPTION
## Summary
- style log meta data so block/week/day appear as visual tags

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872678f9e748332af93b10649135be1