### PR TITLE
Handle JSON from issue body

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # training-log-spa
+
+This repository manages daily training logs using GitHub Issues. To add or update a log, open an issue using the `Training Log` template and paste the JSON payload directly into the description. The automation workflow extracts the JSON block from the issue body and saves it under `public/logs/`.

--- a/scripts/updateLog.js
+++ b/scripts/updateLog.js
@@ -23,9 +23,24 @@ if (!payload) {
   console.error('JSON_PAYLOAD env var is required');
   process.exit(1);
 }
+
+let jsonString = payload.trim();
+if (!jsonString.startsWith('{')) {
+  // try to extract JSON block from issue body
+  // remove common code fences
+  jsonString = jsonString.replace(/```(?:json)?/gi, '').replace(/```/g, '');
+  const match = jsonString.match(/\{[\s\S]*\}/);
+  if (match) {
+    jsonString = match[0];
+  } else {
+    console.error('Invalid JSON payload');
+    process.exit(1);
+  }
+}
+
 let data;
 try {
-  data = JSON.parse(payload);
+  data = JSON.parse(jsonString);
 } catch (e) {
   console.error('Invalid JSON payload');
   throw e;


### PR DESCRIPTION
## Summary
- parse JSON block from issue body in `updateLog.js`
- document how to submit logs using issues

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687267d0b2c88332ad334304d03c7d56