### PR TITLE
Improve navigation icons and meta visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Training Log SPA</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 </head>
 <body>
   <div id="app"></div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,8 +3,8 @@
     <header class="nav-container">
       <div class="logo">🏋️ PowerLog</div>
       <nav>
-        <router-link to="/calendar">カレンダー</router-link>
-        <router-link to="/list">一覧</router-link>
+        <router-link to="/calendar"><span class="material-icons">calendar_month</span></router-link>
+        <router-link to="/list"><span class="material-icons">list</span></router-link>
       </nav>
     </header>
     <main>

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -63,6 +63,10 @@ nav a {
 nav a:hover {
   color: #fff;
 }
+nav .material-icons {
+  font-size: 1.5rem;
+  vertical-align: middle;
+}
 
 /* メインコンテナ */
 main {
@@ -167,16 +171,17 @@ main {
   margin-bottom: var(--spacing);
 }
 .meta {
-  font-weight: 500;
-  color: var(--muted);
+  font-weight: 600;
+  color: var(--text);
   margin-bottom: var(--spacing);
 }
 .meta span {
   display: inline-block;
   background: var(--primary-light);
   color: var(--primary-dark);
-  font-size: 0.75rem;
-  padding: 2px 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 4px 8px;
   border-radius: var(--radius);
   margin-right: 6px;
 }


### PR DESCRIPTION
## Summary
- add Material Icons dependency
- show icons in navbar instead of text
- add icon styles
- make block/week/day tags larger and darker

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687268d74cb48332afbe5ab147ddac9f