### PR TITLE
Fix workflow push permissions

### DIFF
--- a/.github/workflows/add-log.yml
+++ b/.github/workflows/add-log.yml
@@ -1,5 +1,9 @@
 name: Add or Update Training Log
 
+permissions:
+  contents: write
+  issues: read
+
 on:
   issues:
     types: [opened, edited]


### PR DESCRIPTION
## Summary
- allow the Add or Update Training Log workflow to push changes

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6872699a3d548332878d7b8376e307c1