### PR TITLE
Improve tag readability

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -177,8 +177,8 @@ main {
 }
 .meta span {
   display: inline-block;
-  background: var(--primary-light);
-  color: var(--primary-dark);
+  background: var(--primary);
+  color: #fff;
   font-size: 0.875rem;
   font-weight: 600;
   padding: 4px 8px;
@@ -204,8 +204,8 @@ main {
 }
 .type-tag {
   display: inline-block;
-  background: var(--primary-light);
-  color: var(--primary-dark);
+  background: var(--primary);
+  color: #fff;
   font-size: 0.75rem;
   padding: 2px 6px;
   border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- make block/week/day tags readable with white text on the main accent color
- use the same style for session type tags

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726ae08880833295ff6a22b439521c