### PR TITLE
Update meta tag color for readability

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -178,7 +178,7 @@ main {
 .meta span {
   display: inline-block;
   background: var(--primary-light);
-  color: var(--primary-dark);
+  color: var(--text);
   font-size: 0.875rem;
   font-weight: 600;
   padding: 4px 8px;


### PR DESCRIPTION
## Summary
- adjust `.meta span` text color to use `--text` for better contrast

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68726ae9365c83328bda8e7af2010c0a