### PR TITLE
Add default title in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/training-log.yml
+++ b/.github/ISSUE_TEMPLATE/training-log.yml
@@ -1,5 +1,6 @@
 name: "Training Log"
 description: "Register a daily training log in JSON format"
+title: "Training Log"
 labels: ["training-log"]
 body:
   - type: textarea


### PR DESCRIPTION
## Summary
- set a default title for `Training Log` issues

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68726b0267dc83328902eee9f810f20d