### PR TITLE
Display date header in log detail

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -164,6 +164,16 @@ main {
   color: var(--primary);
   margin-bottom: 0.5rem;
 }
+.log-title {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing);
+}
+.log-title .meta {
+  margin-bottom: 0;
+}
 .log-detail {
   padding: var(--spacing);
   background: var(--card-bg);

--- a/src/components/LogDetail.vue
+++ b/src/components/LogDetail.vue
@@ -1,11 +1,13 @@
 <!-- src/components/LogDetail.vue -->
 <template>
   <div class="log-detail" v-if="log">
-    <!-- メタ情報 -->
-    <div class="meta">
-      <span>ブロック: {{ log.block || '-' }}</span>
-      <span>Week: {{ log.week || '-' }}</span>
-      <span>Day: {{ log.day || '-' }}</span>
+    <div class="log-title">
+      <h2>{{ log.date }}</h2>
+      <div class="meta">
+        <span>ブロック: {{ log.block || '-' }}</span>
+        <span>Week: {{ log.week || '-' }}</span>
+        <span>Day: {{ log.day || '-' }}</span>
+      </div>
     </div>
     <p v-if="log.notes" class="notes">{{ log.notes }}</p>
 


### PR DESCRIPTION
## Summary
- show date with block/week/day next to it when viewing a log
- add flex layout for new header

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68726c6eef188332b0c41a8d1d15e386