### PR TITLE
Auto-close log issues

### DIFF
--- a/.github/workflows/add-log.yml
+++ b/.github/workflows/add-log.yml
@@ -2,7 +2,7 @@ name: Add or Update Training Log
 
 permissions:
   contents: write
-  issues: read
+  issues: write
 
 on:
   issues:
@@ -30,3 +30,14 @@ jobs:
             git add public/logs
             git commit -m "Update training log" && git push
           fi
+      - name: Close issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed'
+            });

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # training-log-spa
 
-This repository manages daily training logs using GitHub Issues. To add or update a log, open an issue using the `Training Log` template and paste the JSON payload directly into the description. The automation workflow extracts the JSON block from the issue body and saves it under `public/logs/`.
+This repository manages daily training logs using GitHub Issues. To add or update a log, open an issue using the `Training Log` template and paste the JSON payload directly into the description. The automation workflow extracts the JSON block from the issue body and saves it under `public/logs/`. Once the log is processed, the issue is automatically closed.


### PR DESCRIPTION
## Summary
- auto-close GitHub issues after logging is committed
- document the auto-closing behaviour in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68726db7ca508332975b6f5c8a91854b