### PR TITLE
Floor 1RM values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # training-log-spa
 
 This repository manages daily training logs using GitHub Issues. To add or update a log, open an issue using the `Training Log` template and paste the JSON payload directly into the description. The automation workflow extracts the JSON block from the issue body and saves it under `public/logs/`.
+
+Computed `1RM` and `e1RM` values are rounded down to the nearest whole number when the log is processed.

--- a/scripts/updateLog.js
+++ b/scripts/updateLog.js
@@ -14,8 +14,8 @@ function computeSdE1RM(w, r, rpe) {
   return w * (r + 10 - rpe) / 33.3 + w;
 }
 
-function round2(n) {
-  return Math.round(n * 100) / 100;
+function floorInt(n) {
+  return Math.floor(n);
 }
 
 const payload = process.env.JSON_PAYLOAD;
@@ -61,11 +61,11 @@ for (const session of data.sessions || []) {
     const r = set.reps;
     const rpe = set.rpe;
     if (type.includes('ベンチ')) {
-      set['1RM'] = round2(computeBench1RM(w, r));
-      set.e1RM = round2(computeBenchE1RM(w, r, rpe));
+      set['1RM'] = floorInt(computeBench1RM(w, r));
+      set.e1RM = floorInt(computeBenchE1RM(w, r, rpe));
     } else {
-      set['1RM'] = round2(computeSd1RM(w, r));
-      set.e1RM = round2(computeSdE1RM(w, r, rpe));
+      set['1RM'] = floorInt(computeSd1RM(w, r));
+      set.e1RM = floorInt(computeSdE1RM(w, r, rpe));
     }
   }
 }


### PR DESCRIPTION
## Summary
- round down `1RM` and `e1RM` calculations in updateLog.js
- note the rounding behavior in the README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726e66c6288332a661767804488d1c