### PR TITLE
Display week-day together

### DIFF
--- a/src/components/LogDetail.vue
+++ b/src/components/LogDetail.vue
@@ -5,8 +5,7 @@
       <h2>{{ log.date }}</h2>
       <div class="meta">
         <span>ブロック: {{ log.block || '-' }}</span>
-        <span>Week: {{ log.week || '-' }}</span>
-        <span>Day: {{ log.day || '-' }}</span>
+        <span>Week-Day: {{ log.week != null && log.day != null ? `${log.week}-${log.day}` : '-' }}</span>
       </div>
     </div>
     <p v-if="log.notes" class="notes">{{ log.notes }}</p>


### PR DESCRIPTION
## Summary
- show week-day together in LogDetail

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687270c6a9688332878e33e8c9fd472c