### PR TITLE
Add delete log workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/delete-log.yml
+++ b/.github/ISSUE_TEMPLATE/delete-log.yml
@@ -1,0 +1,11 @@
+name: "Delete Training Log"
+description: "Remove an existing training log by date"
+title: "Delete Training Log"
+labels: ["delete-log"]
+body:
+  - type: textarea
+    attributes:
+      label: "Deletion JSON"
+      description: "Provide a JSON object like `{ \"date\": \"YYYY-MM-DD\" }` or `{ \"dates\": [\"2025-01-01\"] }`"
+    validations:
+      required: true

--- a/.github/workflows/delete-log.yml
+++ b/.github/workflows/delete-log.yml
@@ -1,4 +1,4 @@
-name: Add or Update Training Log
+name: Delete Training Log
 
 permissions:
   contents: write
@@ -9,8 +9,8 @@ on:
     types: [opened, edited]
 
 jobs:
-  add-log:
-    if: contains(github.event.issue.labels.*.name, 'training-log')
+  delete-log:
+    if: contains(github.event.issue.labels.*.name, 'delete-log')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,17 +19,17 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - name: Update log files
+      - name: Delete log files
         env:
           JSON_PAYLOAD: ${{ github.event.issue.body }}
-        run: node scripts/updateLog.js
+        run: node scripts/deleteLog.js
       - name: Commit changes
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           if ! git diff --quiet; then
             git add public/logs
-            git commit -m "Update training log" && git push
+            git commit -m "Delete training log" && git push
           fi
       - name: Close issue
         uses: actions/github-script@v6

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ This repository manages daily training logs using GitHub Issues. To add or updat
 
 Computed `1RM` and `e1RM` values are rounded down to the nearest whole number when the log is processed.
 
+To delete an existing log, open an issue with the `Delete Training Log` template
+and supply a JSON object such as `{ "date": "YYYY-MM-DD" }`. The workflow will
+remove the corresponding file from `public/logs/` and update `index.json`.
+

--- a/scripts/deleteLog.js
+++ b/scripts/deleteLog.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+
+const payload = process.env.JSON_PAYLOAD;
+if (!payload) {
+  console.error('JSON_PAYLOAD env var is required');
+  process.exit(1);
+}
+
+let jsonString = payload.trim();
+if (!jsonString.startsWith('{')) {
+  jsonString = jsonString.replace(/```(?:json)?/gi, '').replace(/```/g, '');
+  const match = jsonString.match(/\{[\s\S]*\}/);
+  if (match) {
+    jsonString = match[0];
+  } else {
+    console.error('Invalid JSON payload');
+    process.exit(1);
+  }
+}
+
+let data;
+try {
+  data = JSON.parse(jsonString);
+} catch (e) {
+  console.error('Invalid JSON payload');
+  throw e;
+}
+
+let dates = [];
+if (Array.isArray(data)) {
+  dates = data;
+} else if (Array.isArray(data.dates)) {
+  dates = data.dates;
+} else if (data.date) {
+  dates = [data.date];
+}
+
+if (!dates.length) {
+  console.error('date or dates field is required');
+  process.exit(1);
+}
+
+const repoRoot = path.join(__dirname, '..');
+const logDir = path.join(repoRoot, 'public', 'logs');
+const indexPath = path.join(logDir, 'index.json');
+let index = [];
+if (fs.existsSync(indexPath)) {
+  index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+}
+
+for (const date of dates) {
+  const filePath = path.join(logDir, `${date}.json`);
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+  index = index.filter((d) => d !== date);
+}
+
+fs.writeFileSync(indexPath, JSON.stringify(index, null, 2));
+


### PR DESCRIPTION
## Summary
- allow deleting logs via new `Delete Training Log` issue template
- add workflow to remove logs and update index
- gate existing add-log workflow on label
- document delete feature
- add script to perform deletion

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727143a2bc83329547edd372f91ca6