### PR TITLE
Adjust disabled calendar day color

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -130,7 +130,8 @@ main {
   transition: transform 0.1s, box-shadow 0.2s;
 }
 .day-cell.disabled {
-  color: var(--border, #e5e7eb);
+  /* 色が薄すぎるため、やや濃いめの --muted を使用 */
+  color: var(--muted);
   background: var(--bg);
   cursor: default;
   box-shadow: none;


### PR DESCRIPTION
## Summary
- adjust color of inactive calendar days to be slightly darker

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727184838883328a911e79e4f14d41