### PR TITLE
Add delete buttons for local logs

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -327,6 +327,19 @@ main {
 .log-card.open .details {
   display: block;
 }
+
+.delete-btn {
+  background: #ef4444;
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  cursor: pointer;
+  margin-top: var(--spacing);
+}
+.delete-btn:hover {
+  background: #dc2626;
+}
 @media (max-width: 600px) {
   #controls {
     flex-direction: column;

--- a/src/components/LogDetail.vue
+++ b/src/components/LogDetail.vue
@@ -3,6 +3,7 @@
   <div class="log-detail" v-if="log">
     <div class="log-title">
       <h2>{{ log.date }}</h2>
+      <button class="delete-btn" @click="confirmDelete">削除</button>
       <div class="meta">
         <span>ブロック: {{ log.block || '-' }}</span>
         <span>{{ log.week != null && log.day != null ? `Week${log.week}-${log.day}` : '-' }}</span>
@@ -52,10 +53,18 @@
 <script>
 export default {
   name: 'LogDetail',
+  emits: ['delete-log'],
   props: {
     log: {
       type: Object,
       required: true
+    }
+  },
+  methods: {
+    confirmDelete() {
+      if (confirm('本当に削除しますか？')) {
+        this.$emit('delete-log', this.log.date)
+      }
     }
   }
 }

--- a/src/components/LogList.vue
+++ b/src/components/LogList.vue
@@ -35,6 +35,7 @@
             </table>
           </div>
         </div>
+        <button class="delete-btn" @click="confirmDelete(log.date)">削除</button>
       </div>
     </div>
 
@@ -50,6 +51,7 @@
 <script>
 export default {
   name: 'LogList',
+  emits: ['delete-log'],
   props: {
     logs: {
       type: Array,
@@ -97,6 +99,11 @@ export default {
       if (this.currentPage < this.totalPages) {
         this.currentPage++;
         this.openDates = [];
+      }
+    },
+    confirmDelete(date) {
+      if (confirm('本当に削除しますか？')) {
+        this.$emit('delete-log', date)
       }
     }
   }

--- a/src/utils/logStorage.js
+++ b/src/utils/logStorage.js
@@ -28,6 +28,12 @@ export function saveLog(log) {
   localStorage.setItem(`log:${log.date}`, JSON.stringify(log));
 }
 
+export function deleteLog(date) {
+  const dates = getStoredDates().filter(d => d !== date);
+  localStorage.setItem(INDEX_KEY, JSON.stringify(dates));
+  localStorage.removeItem(`log:${date}`);
+}
+
 function bench1RM(w, r) {
   return w * r / 40 + w;
 }

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -3,7 +3,7 @@
     <Calendar :available-dates="dates" @select-date="fetchLog" />
     <section id="logContainer">
       <p v-if="!selectedLog">カレンダーの日付をクリックして、詳細を表示してください。</p>
-      <LogDetail v-else :log="selectedLog" />
+      <LogDetail v-else :log="selectedLog" @delete-log="handleDelete" />
     </section>
   </section>
 </template>
@@ -11,7 +11,7 @@
 <script>
 import Calendar from '../components/Calendar.vue'
 import LogDetail from '../components/LogDetail.vue'
-import { getStoredDates, getStoredLog } from '../utils/logStorage'
+import { getStoredDates, getStoredLog, deleteLog } from '../utils/logStorage'
 
 export default {
   components: { Calendar, LogDetail },
@@ -38,6 +38,13 @@ export default {
       fetch(`${base}logs/${date}.json`)
         .then(r => r.json())
         .then(j => this.selectedLog = j)
+    },
+    handleDelete(date) {
+      deleteLog(date)
+      this.dates = this.dates.filter(d => d !== date)
+      if (this.selectedLog && this.selectedLog.date === date) {
+        this.selectedLog = null
+      }
     }
   }
 }

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -7,20 +7,20 @@
         </select> 件
       </label>
     </div>
-    <LogList :logs="logs" :page-size="pageSize" />
+    <LogList :logs="logs" :page-size="pageSize" @delete-log="deleteLogEntry" />
   </div>
 </template>
 
 <script>
 import LogList from '../components/LogList.vue'
-import { getStoredDates, getStoredLog } from '../utils/logStorage'
+import { getStoredDates, getStoredLog, deleteLog } from '../utils/logStorage'
 
 export default {
   components: { LogList },
   data() {
     return { logs: [], pageSize: 10 }
   },
-    created() {
+  created() {
       const base = import.meta.env.BASE_URL
       fetch(`${base}logs/index.json`)
         .then(r => r.json())
@@ -37,6 +37,12 @@ export default {
           arr.sort((a, b) => a.date.localeCompare(b.date))
           this.logs = arr
         })
+  },
+  methods: {
+    deleteLogEntry(date) {
+      deleteLog(date)
+      this.logs = this.logs.filter(l => l.date !== date)
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- allow deletion of local logs with new `deleteLog` util
- show delete button in log details and log list entries
- handle deletion in calendar and list views
- add styles for delete button

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727770a2408332916435ab76d5489d