### PR TITLE
Hide null block and week-day

### DIFF
--- a/src/components/LogDetail.vue
+++ b/src/components/LogDetail.vue
@@ -5,8 +5,8 @@
       <h2>{{ log.date }}</h2>
       <button class="delete-btn" @click="confirmDelete">削除</button>
       <div class="meta">
-        <span>ブロック: {{ log.block || '-' }}</span>
-        <span>{{ log.week != null && log.day != null ? `Week${log.week}-${log.day}` : '-' }}</span>
+        <span v-if="log.block != null">ブロック: {{ log.block }}</span>
+        <span v-if="log.week != null && log.day != null">Week{{ log.week }}-{{ log.day }}</span>
       </div>
     </div>
     <p v-if="log.notes" class="notes">{{ log.notes }}</p>


### PR DESCRIPTION
## Summary
- don't show block or week-day info when values are null

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727ad09dd8833284c041eb51e74837