### PR TITLE
Fix overflow of prompt detail section

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -391,6 +391,12 @@ main {
   font-weight: 600;
 }
 
+#register-section pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
 #register-section textarea {
   width: 100%;
   padding: var(--spacing);


### PR DESCRIPTION
## Summary
- keep prompt text from overflowing register view

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727b5922e0833299c31957729ce083