### PR TITLE
Display block/week info in list view

### DIFF
--- a/src/components/LogList.vue
+++ b/src/components/LogList.vue
@@ -12,6 +12,10 @@
         <span class="note">{{ log.notes || '' }}</span>
       </div>
       <div class="details">
+        <div class="meta" v-if="log.block != null || (log.week != null && log.day != null)">
+          <span v-if="log.block != null">ブロック: {{ log.block }}</span>
+          <span v-if="log.week != null && log.day != null">Week{{ log.week }}-{{ log.day }}</span>
+        </div>
         <div v-for="session in log.sessions" :key="session.lift" class="session">
           <h2>
             {{ session.lift }}


### PR DESCRIPTION
## Summary
- show training block and week-day details in each log card

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727c94ab6c83328586cf4755a0d06b