### PR TITLE
Add prompt copy button

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -434,3 +434,7 @@ main {
   color: var(--primary-dark);
   font-weight: 600;
 }
+
+#register-section .copy-btn {
+  margin-bottom: 8px;
+}

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -4,7 +4,8 @@
     <p class="prompt-note">ChatGPTに下記プロンプトを入力してJSONを生成できます。</p>
     <details>
       <summary>プロンプトを表示</summary>
-      <pre>
+      <button class="copy-btn" @click="copyPrompt">コピー</button>
+      <pre ref="promptText">
 あなたはパワーリフティング競技者のトレーニング記録を支援するAIコーチです。
 
 以下のルールに従って、トレーニングログをJSON形式で正確に出力してください。  
@@ -140,6 +141,11 @@ export default {
       saveLog(obj)
       this.jsonInput = ''
       this.message = '登録しました'
+    },
+    copyPrompt() {
+      const text = this.$refs.promptText.textContent
+      navigator.clipboard.writeText(text)
+      this.message = 'プロンプトをコピーしました'
     }
   }
 }


### PR DESCRIPTION
## Summary
- make prompt text copyable

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727cc624cc8332b174283599b37db5