### PR TITLE
表示件数スライダーのUI改善

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -315,6 +315,17 @@ main {
 #controls label {
   font-weight: 500;
 }
+#controls label.page-size {
+  display: inline-flex;
+  align-items: center;
+}
+#controls label.page-size .material-icons {
+  margin-right: 4px;
+  font-size: 20px;
+}
+#controls label.page-size .current {
+  margin-left: 4px;
+}
 #controls select,
 #controls input[type="range"] {
   margin-left: 8px;

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
     <div id="controls">
-      <label>表示件数:
+      <label class="page-size">
+        <span class="material-icons">format_list_numbered</span>
         <input
           type="range"
           v-model.number="pageSize"
@@ -9,7 +10,7 @@
           max="100"
           step="10"
         />
-        <span>{{ pageSize }}</span> 件
+        <span class="current">{{ pageSize }}</span>
       </label>
       <div class="segmented-control">
         <button :class="{ active: view === 'logs' }" @click="view = 'logs'">ログ</button>


### PR DESCRIPTION
## 変更点
- 表示件数変更スライダーにアイコンを追加し、数値表示をシンプルにしました
- スタイルを調整しアイコンと値が横並びになるようにしました

## 動作確認
- `npm test` を実行しましたが `vitest` が見つからず失敗しました


------
https://chatgpt.com/codex/tasks/task_e_6878cdab31608332a2676bf6aba23e75