### PR TITLE
UI: ピル型タブで切り替えを強化

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -675,6 +675,38 @@ main {
   border-right: 1px solid var(--border);
 }
 
+/* スライダー付きピル型タブ */
+.segmented-pill {
+  position: relative;
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--card-bg);
+  overflow: hidden;
+}
+.segmented-pill .slider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 50%;
+  background: var(--primary);
+  border-radius: inherit;
+  transition: transform 0.2s;
+}
+.segmented-pill button {
+  flex: 1;
+  border: none;
+  background: none;
+  padding: 4px 12px;
+  cursor: pointer;
+  color: var(--text);
+  z-index: 1;
+}
+.segmented-pill button.active {
+  color: var(--bg);
+}
+
 /* 一覧表示テーブル */
 .flat-table {
   width: 100%;

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -12,7 +12,8 @@
         />
         <span class="current">{{ pageSize }}</span>
       </label>
-      <div class="segmented-control">
+      <div class="segmented-pill">
+        <div class="slider" :style="viewSliderStyle"></div>
         <button :class="{ active: view === 'logs' }" @click="view = 'logs'">ログ</button>
         <button :class="{ active: view === 'schedule' }" @click="view = 'schedule'">スケジュール</button>
       </div>
@@ -37,7 +38,8 @@
           @click="baseModel = opt.value"
         >{{ opt.label }}</button>
       </div>
-      <div class="segmented-control variant-tabs" v-if="view === 'logs' && showVariant">
+      <div class="segmented-pill variant-tabs" v-if="view === 'logs' && showVariant">
+        <div class="slider" :style="variantSliderStyle"></div>
         <button
           :class="{ active: variantModel === '' }"
           @click="variantModel = ''"
@@ -123,6 +125,16 @@ export default {
     },
     variants() {
       return ['メイン', 'サブ']
+    },
+    viewSliderStyle() {
+      const idx = this.view === 'logs' ? 0 : 1
+      return { transform: `translateX(${idx * 100}%)` }
+    },
+    variantSliderStyle() {
+      const opts = ['', 'メイン', 'サブ']
+      const idx = opts.indexOf(this.variantModel)
+      const w = 100 / opts.length
+      return { width: `${w}%`, transform: `translateX(${idx * w}%)` }
     },
     filteredLogs() {
       const variant = this.variantModel


### PR DESCRIPTION
## 概要
- ログ/スケジュールとメイン/サブの切り替えが単調だったため、スライダー付きのピル型タブを導入しました
- CSS に `segmented-pill` クラスを追加
- `ListView.vue` でタブ UI を更新し、スライダーの位置を計算する処理を実装

## テスト
- `npm run test` を実行しましたが、`vitest` が見つからずテストを実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_6878cf13bf78833284a417e0c8a4df01