### PR TITLE
メイン/サブのタグをアイコン付きで表示

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -243,7 +243,9 @@ main {
   flex-wrap: wrap;
 }
 .type-tag {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
   background: #F0566E;
   color: #b22d35;
   font-size: 0.65rem;
@@ -253,6 +255,17 @@ main {
   line-height: 1;
   white-space: nowrap;
   cursor: pointer;
+}
+.type-tag .material-icons {
+  font-size: 1rem;
+}
+.tag-main {
+  background: #ff9800;
+  color: #ffffff;
+}
+.tag-sub {
+  background: #2196f3;
+  color: #ffffff;
 }
 .session .table-wrapper {
   overflow-x: auto;
@@ -747,6 +760,9 @@ main {
   padding: 1px 4px;
   margin-left: 0;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
 }
 .flat-session + .flat-session {
   margin-top: 4px;

--- a/src/components/LogList.vue
+++ b/src/components/LogList.vue
@@ -23,9 +23,12 @@
             <span v-if="session.variation"> ({{ session.variation }})</span>
             <span
               v-if="session.type"
-              class="type-tag"
+              :class="['type-tag', variantClass(session.type)]"
               @click.stop="goCategory(session.type)"
-            >{{ session.type }}</span>
+            >
+              <span class="material-icons">{{ variantIcon(session.type) }}</span>
+              {{ session.type }}
+            </span>
           </h2>
           <div class="table-wrapper">
             <table>
@@ -153,6 +156,18 @@ export default {
       if (confirm('本当に削除しますか？')) {
         this.$emit('delete-log', date)
       }
+    },
+    variantClass(type) {
+      const { variant } = parseCategory(type)
+      if (variant === 'メイン') return 'tag-main'
+      if (variant === 'サブ') return 'tag-sub'
+      return ''
+    },
+    variantIcon(type) {
+      const { variant } = parseCategory(type)
+      if (variant === 'メイン') return 'fitness_center'
+      if (variant === 'サブ') return 'construction'
+      return 'label'
     },
     isAccessoryType
   }


### PR DESCRIPTION
## 変更内容
- LogList にカテゴリタグ用のアイコン表示を追加
- メイン・サブ判定用メソッドと CSS クラスを定義
- タグ用スタイルを調整し、新しい色を適用

## テスト
- `npm run test` を実行（依存パッケージ欠如のため失敗）

------
https://chatgpt.com/codex/tasks/task_e_6878d0e223b0833284114076fb73cf39