### PR TITLE
variantタブのデザイン刷新

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -362,6 +362,16 @@ main {
 }
 #controls .variant-tabs {
   margin-left: 8px;
+  border-color: var(--primary);
+}
+
+#controls .variant-tabs button {
+  color: var(--primary);
+}
+
+#controls .variant-tabs button.active {
+  background: var(--primary);
+  color: var(--bg);
 }
 .category-select select {
   -webkit-appearance: none;

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -38,8 +38,7 @@
           @click="baseModel = opt.value"
         >{{ opt.label }}</button>
       </div>
-      <div class="segmented-pill variant-tabs" v-if="view === 'logs' && showVariant">
-        <div class="slider" :style="variantSliderStyle"></div>
+      <div class="segmented-control variant-tabs" v-if="view === 'logs' && showVariant">
         <button
           :class="{ active: variantModel === '' }"
           @click="variantModel = ''"
@@ -129,12 +128,6 @@ export default {
     viewSliderStyle() {
       const idx = this.view === 'logs' ? 0 : 1
       return { transform: `translateX(${idx * 100}%)` }
-    },
-    variantSliderStyle() {
-      const opts = ['', 'メイン', 'サブ']
-      const idx = opts.indexOf(this.variantModel)
-      const w = 100 / opts.length
-      return { width: `${w}%`, transform: `translateX(${idx * w}%)` }
     },
     filteredLogs() {
       const variant = this.variantModel


### PR DESCRIPTION
## 概要
- 一覧ページの`全て・メイン・サブ`切り替えを`segmented-control`方式に変更
- `variant-tabs`のスタイルを更新し、枠線と文字色をプライマリカラーに変更

## テスト
- `npm run test` を実行しましたが、`vitest` が見つからず失敗しました

------
https://chatgpt.com/codex/tasks/task_e_6878d2a1568483328692f66dce1317fc