### PR TITLE
カレンダー表示のちらつき解消

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -9,7 +9,7 @@
 
     <!-- カレンダー本体 -->
     <div id="calendarContainer">
-      <transition :name="'slide-' + slideDirection">
+      <transition :name="'slide-' + slideDirection" mode="in-out">
         <div
           :key="viewYear + '-' + viewMonth"
           id="calendar"


### PR DESCRIPTION
## 概要
カレンダースワイプ時に一瞬カレンダーが消える問題を修正しました。

## 変更点
- `Calendar.vue` の `<transition>` に `mode="in-out"` を追加し、次の月の要素が表示されるまで前月が残るようにしました。

## テスト
- `npm test` を試行しましたが、依存パッケージがインストールできず実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_687917283aa48332babe3c915510ff35