### PR TITLE
改善: カレンダーのスワイプ挙動

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -9,7 +9,8 @@
 
     <!-- カレンダー本体 -->
     <div id="calendarContainer">
-      <transition :name="'slide-' + slideDirection" mode="in-out">
+      <transition :name="'slide-' + slideDirection" mode="in-out"
+                  @before-leave="onBeforeLeave">
         <div
           :key="viewYear + '-' + viewMonth"
           id="calendar"
@@ -67,7 +68,8 @@ export default {
       touchStartX: null,
       slideDirection: 'left',
       dragOffset: 0,
-      dragging: false
+      dragging: false,
+      releaseOffset: null
     };
   },
   computed: {
@@ -140,13 +142,22 @@ export default {
       const endX = e.changedTouches[0].screenX;
       const diff = endX - this.touchStartX;
       if (diff > 50) {
+        this.releaseOffset = diff;
         this.prevMonth();
+        setTimeout(() => this.releaseOffset = null, 300);
       } else if (diff < -50) {
+        this.releaseOffset = diff;
         this.nextMonth();
+        setTimeout(() => this.releaseOffset = null, 300);
       }
       this.dragOffset = 0;
       this.dragging = false;
       this.touchStartX = null;
+    },
+    onBeforeLeave(el) {
+      if (this.releaseOffset !== null) {
+        el.style.transform = `translateX(${this.releaseOffset}px)`;
+      }
     }
   }
 };


### PR DESCRIPTION
## 概要
- スワイプ後に指を離した際、前後の月が滑らかに入れ替わるように修正しました
- 旧月が指の位置からそのまま画面外までスライドするため、違和感のないアニメーションになります

## 変更点
- `releaseOffset` を追加し、スワイプ終了時の位置を保持
- トランジション開始前に旧要素へオフセットを適用
- 月送り後に一定時間でオフセットをリセット

## テスト
- `npm run test` を実行しましたが、依存パッケージが無いため失敗しました

------
https://chatgpt.com/codex/tasks/task_e_68791ba9f59c8332823d8be883f4d7c0