### PR TITLE
曜日ヘッダーの固定表示

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -115,6 +115,14 @@ main {
   text-align: center;
 }
 
+/* 固定曜日ヘッダー用グリッド */
+#weekdayHeader {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+  margin-bottom: var(--spacing);
+}
+
 /* カレンダーグリッド */
 #calendar {
   display: grid;

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -7,6 +7,13 @@
       <button @click="nextMonth">▶︎</button>
     </div>
 
+    <!-- 曜日ヘッダー -->
+    <div id="weekdayHeader">
+      <div v-for="w in weekdays" :key="w" class="weekday">
+        {{ w }}
+      </div>
+    </div>
+
     <!-- カレンダー本体 -->
     <div id="calendarContainer">
       <transition :name="'slide-' + slideDirection" mode="in-out"
@@ -16,10 +23,6 @@
           id="calendar"
           :style="dragging ? { transform: `translateX(${dragOffset}px)`, transition: 'none' } : {}"
         >
-          <!-- 曜日ヘッダー -->
-          <div v-for="w in weekdays" :key="w" class="weekday">
-            {{ w }}
-          </div>
           <!-- 空セル -->
           <div v-for="n in firstDay" :key="'e'+n" class="day-cell disabled"></div>
           <!-- 日セル -->


### PR DESCRIPTION
## 変更内容
- カレンダー表示を調整し、スワイプ時に曜日ヘッダーが動かないようにしました
- `weekdayHeader` 用のスタイルを追加

## 動作確認
- `npm test` を実行しましたが `vitest` が見つからずテストを実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_6879ac66ad78833281701ca4d91e38f4