### PR TITLE
カレンダーのスライドアニメーション改善

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -16,7 +16,7 @@
 
     <!-- カレンダー本体 -->
     <div id="calendarContainer">
-      <transition :name="'slide-' + slideDirection" mode="in-out"
+      <transition :name="'slide-' + slideDirection"
                   @before-leave="onBeforeLeave">
         <div
           :key="viewYear + '-' + viewMonth"


### PR DESCRIPTION
## Summary
- カレンダーをスワイプした際、前月と次月の表示が同時にスライドするよう変更

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879af7743a883328c6c662845ff8f03