### PR TITLE
カレンダー遷移のちらつき解消

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -16,7 +16,7 @@
 
     <!-- カレンダー本体 -->
     <div id="calendarContainer">
-      <transition :name="'slide-' + slideDirection"
+      <transition :name="'slide-' + slideDirection" mode="in-out"
                   @before-leave="onBeforeLeave">
         <div
           :key="viewYear + '-' + viewMonth"


### PR DESCRIPTION
## 概要
スワイプで月を切り替える際に、一瞬カレンダーが消える現象があったため、`<transition>`に `mode="in-out"` を追加しました。これにより新しいカレンダーが先に表示され、常にどちらかのカレンダーが表示され続けます。

## テスト
- `npm test` を実行しようとしましたが、環境に Node.js がないため実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_6879b1efad708332b3cbee341a08e42a