### PR TITLE
タグデザイン統一

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -148,14 +148,14 @@ main {
   box-shadow: none;
 }
 .day-cell.has-log {
-  border-color: #b22d35;
-  background: #b22d35;
-  color: #ffffff;
+  border-color: #F0566E;
+  background: #F0566E;
+  color: #b22d35;
 }
 .day-cell.has-schedule {
-  border-color: var(--schedule-dark);
-  background: var(--schedule-light);
-  color: var(--schedule-dark);
+  border-color: #2196f3;
+  background: #2196f3;
+  color: #ffffff;
 }
 .day-cell:hover:not(.disabled) {
   transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- カレンダーのタグ色をリストのスタイルに合わせる

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a19b198508332bd05455bc455eaa3