### PR TITLE
種目履歴モーダルの追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,14 +18,17 @@
     <main>
       <router-view />
     </main>
+    <PastLogsModal />
   </div>
 </template>
 
 <script>
 import { getUsers, setUser } from './utils/user'
+import PastLogsModal from './components/PastLogsModal.vue'
 
 export default {
   name: 'App',
+  components: { PastLogsModal },
   data() {
     return {
       userMenu: false,

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -244,6 +244,13 @@ main {
   white-space: nowrap;
   overflow-x: auto;
 }
+.lift-link {
+  text-decoration: underline;
+  cursor: pointer;
+}
+.lift-link:hover {
+  color: var(--primary-light);
+}
 
 /* スケジュールのセッションタイトルは横スクロールさせない */
 .schedule-detail .session-title {

--- a/src/components/LogDetail.vue
+++ b/src/components/LogDetail.vue
@@ -17,7 +17,7 @@
       class="session"
     >
       <h3 class="session-title">
-        {{ session.lift }}
+        <span class="lift-link" @click="showHistory(session.lift)">{{ session.lift }}</span>
         <small v-if="session.variation">({{ session.variation }})</small>
         <span
           v-if="session.type"
@@ -55,6 +55,7 @@
 
 <script>
 import { parseCategory, isAccessoryType } from '../utils/category'
+import { showLiftModal } from '../utils/liftModal'
 export default {
   name: 'LogDetail',
   emits: ['delete-log'],
@@ -62,6 +63,10 @@ export default {
     log: {
       type: Object,
       required: true
+    },
+    allLogs: {
+      type: Array,
+      default: () => []
     }
   },
   methods: {
@@ -75,6 +80,9 @@ export default {
       const query = {}
       if (variant) query.variant = variant
       this.$router.push({ path: `/list/${encodeURIComponent(base)}`, query })
+    },
+    showHistory(lift) {
+      showLiftModal(lift, this.allLogs)
     },
     isAccessoryType
   }

--- a/src/components/LogList.vue
+++ b/src/components/LogList.vue
@@ -19,7 +19,7 @@
       <div class="details">
         <div v-for="session in log.sessions" :key="session.lift" class="session">
           <h2>
-            {{ session.lift }}
+            <span class="lift-link" @click="showHistory(session.lift)">{{ session.lift }}</span>
             <span v-if="session.variation"> ({{ session.variation }})</span>
             <span
               v-if="session.type"
@@ -68,11 +68,16 @@
 
 <script>
 import { parseCategory, isAccessoryType } from '../utils/category'
+import { showLiftModal } from '../utils/liftModal'
 export default {
   name: 'LogList',
   emits: ['delete-log'],
   props: {
     logs: {
+      type: Array,
+      default: () => []
+    },
+    allLogs: {
       type: Array,
       default: () => []
     },
@@ -151,6 +156,9 @@ export default {
       const query = {}
       if (variant) query.variant = variant
       this.$router.push({ path: `/list/${encodeURIComponent(base)}`, query })
+    },
+    showHistory(lift) {
+      showLiftModal(lift, this.allLogs)
     },
     confirmDelete(date) {
       if (confirm('本当に削除しますか？')) {

--- a/src/components/PastLogsModal.vue
+++ b/src/components/PastLogsModal.vue
@@ -1,0 +1,94 @@
+<template>
+  <div v-if="state.visible" class="modal-overlay" @click.self="close">
+    <div class="modal">
+      <header>
+        <h3>{{ state.lift }} の過去ログ</h3>
+        <button class="close-btn" @click="close">×</button>
+      </header>
+      <table>
+        <thead>
+          <tr><th>日付</th><th>セット</th></tr>
+        </thead>
+        <tbody>
+          <tr v-for="(s, i) in state.sessions" :key="i">
+            <td>{{ s.date }}</td>
+            <td class="sets">{{ formatSets(s.sets) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import { useLiftModal, hideLiftModal } from '../utils/liftModal'
+export default {
+  name: 'PastLogsModal',
+  setup() {
+    const state = useLiftModal()
+    const close = () => hideLiftModal()
+    const formatSets = sets =>
+      sets.map(set => {
+        const w = set.weight != null ? set.weight + 'kg' : ''
+        const r = set.reps != null ? set.reps + 'rep' : ''
+        return [w, r].filter(Boolean).join('×')
+      }).join(', ')
+    return { state, close, formatSets }
+  }
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 300;
+}
+.modal {
+  background: var(--card-bg);
+  color: var(--text);
+  padding: var(--spacing);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 12px var(--shadow);
+  max-height: 80vh;
+  overflow-y: auto;
+  width: 280px;
+}
+.modal header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.modal header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+.close-btn {
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+.modal table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.modal th,
+.modal td {
+  padding: 4px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+.modal td.sets {
+  white-space: pre-wrap;
+}
+</style>

--- a/src/components/ScheduleDetail.vue
+++ b/src/components/ScheduleDetail.vue
@@ -9,7 +9,7 @@
     </div>
     <div v-for="(session, idx) in plan.sessions" :key="idx" class="session">
       <h3 class="session-title">
-        {{ session.lift }}
+        <span class="lift-link" @click="showHistory(session.lift)">{{ session.lift }}</span>
         <span
           v-if="session.type"
           class="type-tag"
@@ -44,6 +44,7 @@
 
 <script>
 import { parseCategory, isAccessoryType } from '../utils/category'
+import { showLiftModal } from '../utils/liftModal'
 export default {
   name: 'ScheduleDetail',
   props: {
@@ -54,6 +55,10 @@ export default {
     showMeta: {
       type: Boolean,
       default: false
+    },
+    allLogs: {
+      type: Array,
+      default: () => []
     }
   },
   methods: {
@@ -62,6 +67,9 @@ export default {
       const query = {}
       if (variant) query.variant = variant
       this.$router.push({ path: `/list/${encodeURIComponent(base)}`, query })
+    },
+    showHistory(lift) {
+      showLiftModal(lift, this.allLogs)
     },
     isAccessoryType
   }

--- a/src/components/ScheduleList.vue
+++ b/src/components/ScheduleList.vue
@@ -18,7 +18,7 @@
                   :key="i"
                   class="flat-session"
                 >
-                  <strong>{{ session.lift }}</strong>
+                  <strong class="lift-link" @click.stop="showHistory(session.lift)">{{ session.lift }}</strong>
                   <span class="set-detail">
                     <template v-for="(set, si) in session.sets" :key="si">
                       <span>{{ formatSet(set) }}</span>
@@ -57,7 +57,7 @@
           <span class="note">{{ summaryLifts(plan).join('\n') }}</span>
         </div>
         <div class="details">
-          <ScheduleDetail :plan="plan" />
+          <ScheduleDetail :plan="plan" :all-logs="allLogs" />
         </div>
       </div>
 
@@ -73,6 +73,7 @@
 <script>
 import ScheduleDetail from './ScheduleDetail.vue'
 import { parseCategory, sortCategories } from '../utils/category'
+import { showLiftModal } from '../utils/liftModal'
 
 export default {
   name: 'ScheduleList',
@@ -89,6 +90,10 @@ export default {
     flat: {
       type: Boolean,
       default: false
+    },
+    allLogs: {
+      type: Array,
+      default: () => []
     }
   },
   data() {
@@ -162,6 +167,9 @@ export default {
       const query = {}
       if (variant) query.variant = variant
       this.$router.push({ path: `/list/${encodeURIComponent(base)}`, query })
+    },
+    showHistory(lift) {
+      showLiftModal(lift, this.allLogs)
     }
   }
 }

--- a/src/components/SessionList.vue
+++ b/src/components/SessionList.vue
@@ -9,7 +9,7 @@
       <div class="summary" :class="{ clickable: !expanded }" @click="expanded || toggle(s.id)">
         <span class="date">{{ s.date }}</span>
         <span class="note">
-          {{ s.session.lift }}<span v-if="s.session.variation"> ({{ s.session.variation }})</span>
+          <span class="lift-link" @click.stop="showHistory(s.session.lift)">{{ s.session.lift }}</span><span v-if="s.session.variation"> ({{ s.session.variation }})</span>
         </span>
       </div>
       <div class="details">
@@ -19,7 +19,7 @@
         </div>
         <div class="session">
           <h2>
-            {{ s.session.lift }}
+            <span class="lift-link" @click="showHistory(s.session.lift)">{{ s.session.lift }}</span>
             <span v-if="s.session.variation"> ({{ s.session.variation }})</span>
             <span
               v-if="s.session.type"
@@ -64,10 +64,15 @@
 
 <script>
 import { parseCategory, isAccessoryType } from '../utils/category'
+import { showLiftModal } from '../utils/liftModal'
 export default {
   name: 'SessionList',
   props: {
     sessions: {
+      type: Array,
+      default: () => []
+    },
+    allLogs: {
       type: Array,
       default: () => []
     },
@@ -134,6 +139,9 @@ export default {
       const query = {}
       if (variant) query.variant = variant
       this.$router.push({ path: `/list/${encodeURIComponent(base)}`, query })
+    },
+    showHistory(lift) {
+      showLiftModal(lift, this.allLogs)
     },
     isAccessoryType
   }

--- a/src/utils/liftModal.js
+++ b/src/utils/liftModal.js
@@ -1,0 +1,30 @@
+import { reactive } from 'vue'
+
+const state = reactive({
+  visible: false,
+  lift: '',
+  sessions: []
+})
+
+export function showLiftModal(lift, logs = []) {
+  const sessions = []
+  for (const log of logs) {
+    for (const sess of log.sessions || []) {
+      if (sess.lift === lift) {
+        sessions.push({ date: log.date, sets: sess.sets })
+      }
+    }
+  }
+  sessions.sort((a, b) => b.date.localeCompare(a.date))
+  state.lift = lift
+  state.sessions = sessions
+  state.visible = true
+}
+
+export function hideLiftModal() {
+  state.visible = false
+}
+
+export function useLiftModal() {
+  return state
+}

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -7,8 +7,8 @@
     />
     <section id="logContainer">
       <p v-if="!selectedLog && !selectedPlan">カレンダーの日付をクリックして、詳細を表示してください。</p>
-      <LogDetail v-if="selectedLog" :log="selectedLog" @delete-log="handleDelete" />
-      <ScheduleDetail v-else-if="selectedPlan" :plan="selectedPlan" show-meta />
+      <LogDetail v-if="selectedLog" :log="selectedLog" :all-logs="logs" @delete-log="handleDelete" />
+      <ScheduleDetail v-else-if="selectedPlan" :plan="selectedPlan" :all-logs="logs" show-meta />
     </section>
   </section>
 </template>

--- a/src/views/ListView.vue
+++ b/src/views/ListView.vue
@@ -57,12 +57,14 @@
     <LogList
       v-if="view === 'logs'"
       :logs="filteredLogs"
+      :all-logs="logs"
       :page-size="pageSize"
       @delete-log="deleteLogEntry"
     />
     <ScheduleList
       v-if="view === 'schedule'"
       :plans="plans"
+      :all-logs="logs"
       :page-size="pageSize"
       :flat="flatView"
     />


### PR DESCRIPTION
## Summary
- 種目名をクリックすると過去ログを表示するモーダルを実装
- モーダル用コンポーネントと状態管理を追加
- 各ビュー・リストでモーダルを開けるように修正
- スタイルにlift-linkを追加

## Testing
- `npm test` 実行（依存関係不足により失敗）

------
https://chatgpt.com/codex/tasks/task_e_687a1af42f80833292eba6a4ba95e709