### PR TITLE
モーダルで過去セッションを詳細表示

### DIFF
--- a/src/components/PastLogsModal.vue
+++ b/src/components/PastLogsModal.vue
@@ -2,38 +2,47 @@
   <div v-if="state.visible" class="modal-overlay" @click.self="close">
     <div class="modal">
       <header>
-        <h3>{{ state.lift }} の過去ログ</h3>
+        <h3>{{ state.lift }}</h3>
         <button class="close-btn" @click="close">×</button>
       </header>
-      <table>
-        <thead>
-          <tr><th>日付</th><th>セット</th></tr>
-        </thead>
-        <tbody>
-          <tr v-for="(s, i) in state.sessions" :key="i">
-            <td>{{ s.date }}</td>
-            <td class="sets">{{ formatSets(s.sets) }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <div v-for="(s, i) in state.sessions" :key="i" class="session">
+        <h4 class="date">{{ s.date }}</h4>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>重量(kg)</th>
+                <th>回数</th>
+                <th>RPE</th>
+                <th v-if="!isAccessoryType(s.type)">1RM</th>
+                <th v-if="!isAccessoryType(s.type)">e1RM</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(set, si) in s.sets" :key="si">
+                <td>{{ set.weight }}</td>
+                <td>{{ set.reps }}</td>
+                <td>{{ set.rpe }}</td>
+                <td v-if="!isAccessoryType(s.type)">{{ set['1RM'] ?? '-' }}</td>
+                <td v-if="!isAccessoryType(s.type)">{{ set.e1RM ?? '-' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 import { useLiftModal, hideLiftModal } from '../utils/liftModal'
+import { isAccessoryType } from '../utils/category'
 export default {
   name: 'PastLogsModal',
   setup() {
     const state = useLiftModal()
     const close = () => hideLiftModal()
-    const formatSets = sets =>
-      sets.map(set => {
-        const w = set.weight != null ? set.weight + 'kg' : ''
-        const r = set.reps != null ? set.reps + 'rep' : ''
-        return [w, r].filter(Boolean).join('×')
-      }).join(', ')
-    return { state, close, formatSets }
+    return { state, close, isAccessoryType }
   }
 }
 </script>
@@ -59,7 +68,7 @@ export default {
   box-shadow: 0 4px 12px var(--shadow);
   max-height: 80vh;
   overflow-y: auto;
-  width: 280px;
+  width: 480px;
 }
 .modal header {
   display: flex;
@@ -77,18 +86,5 @@ export default {
   color: var(--text);
   font-size: 1.2rem;
   cursor: pointer;
-}
-.modal table {
-  width: 100%;
-  border-collapse: collapse;
-}
-.modal th,
-.modal td {
-  padding: 4px;
-  border-bottom: 1px solid var(--border);
-  text-align: left;
-}
-.modal td.sets {
-  white-space: pre-wrap;
 }
 </style>

--- a/src/utils/liftModal.js
+++ b/src/utils/liftModal.js
@@ -11,7 +11,11 @@ export function showLiftModal(lift, logs = []) {
   for (const log of logs) {
     for (const sess of log.sessions || []) {
       if (sess.lift === lift) {
-        sessions.push({ date: log.date, sets: sess.sets })
+        sessions.push({
+          date: log.date,
+          type: sess.type,
+          sets: sess.sets
+        })
       }
     }
   }


### PR DESCRIPTION
## 変更内容
- 過去ログモーダルのヘッダーから「〜の過去ログ」を削除
- モーダル幅を480pxに拡大
- セッションごとに重量や回数などの詳細を表形式で表示
- モーダル用状態に種目タイプを保持

## 動作確認
- `npm test` を実行しましたが、`vitest` が存在せず失敗しました

------
https://chatgpt.com/codex/tasks/task_e_687a2348d4308332a448fc23e506e8a6