### PR TITLE
カレンダーのスワイプ改善

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -16,7 +16,7 @@
 
     <!-- カレンダー本体 -->
     <div id="calendarContainer">
-      <transition :name="'slide-' + slideDirection" mode="in-out"
+      <transition :name="'slide-' + slideDirection"
                   @before-leave="onBeforeLeave" @before-enter="onBeforeEnter">
         <div
           :key="viewYear + '-' + viewMonth"
@@ -194,13 +194,14 @@ export default {
 #calendarContainer {
   position: relative;
   overflow: hidden;
+  touch-action: pan-x;
 }
 
 .slide-left-enter-active,
 .slide-left-leave-active,
 .slide-right-enter-active,
 .slide-right-leave-active {
-  transition: transform 0.3s cubic-bezier(0.33, 1, 0.68, 1);
+  transition: transform 0.25s cubic-bezier(0.33, 1, 0.68, 1);
   position: absolute;
   top: 0;
   left: 0;
@@ -212,6 +213,6 @@ export default {
 .slide-right-leave-to   { transform: translateX(100%); }
 
 #calendar {
-  transition: transform 0.3s cubic-bezier(0.33, 1, 0.68, 1);
+  transition: transform 0.25s cubic-bezier(0.33, 1, 0.68, 1);
 }
 </style>


### PR DESCRIPTION
## 概要
カレンダーのスワイプ機能を調整しました。アニメーションの同時実行により、指を離したときに前後の月が滑らかに入れ替わります。また、アニメーション速度を短縮し、横方向のスワイプ操作を明示的に許可しました。

## テスト
- `npm run test` を実行しましたが `vitest` が見つからず失敗しました。

------
https://chatgpt.com/codex/tasks/task_e_687ad6ace5bc8332809c6de71c68068b