### PR TITLE
改善したカレンダースワイプ

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -124,7 +124,7 @@ main {
 }
 
 /* カレンダーグリッド */
-#calendar {
+#calendar, .month {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   gap: 8px;


### PR DESCRIPTION
## 概要
- カレンダー表示を3枚構成にしてドラッグに追従するスワイプを実装
- ボタン操作も新しいアニメーションを使用
- CSSを調整して `.month` クラスでカレンダーを表現

## テスト結果
- `npm test` は `vitest` が無いため実行できず


------
https://chatgpt.com/codex/tasks/task_e_687afd5ed7f08332bc62daec7a0b5333