### PR TITLE
月間カレンダー表示の調整

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -268,5 +268,7 @@ export default {
 
 .month {
   width: 100%;
+  padding: 0 var(--spacing);
+  box-sizing: border-box;
 }
 </style>


### PR DESCRIPTION
## 変更点
- 月ごとのコンテナに左右のパディングを追加し、スワイプ時の月同士の間隔を広げた

## テスト
- `npm test` を実行したが、`vitest` が見つからず失敗（依存パッケージ未インストールのため）

------
https://chatgpt.com/codex/tasks/task_e_687b1100f3448332bdea71cfcbd7b89a