### PR TITLE
Fix weekday header spacing

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -121,6 +121,8 @@ main {
   grid-template-columns: repeat(7, 1fr);
   gap: 8px;
   margin-bottom: var(--spacing);
+  padding: 0 var(--spacing);
+  box-sizing: border-box;
 }
 
 /* カレンダーグリッド */


### PR DESCRIPTION
## Summary
- 曜日ヘッダーにも左右の余白を持たせてカレンダーの列を揃える

## Testing
- `npm run test` *(失敗：`vitest` が見つかりません)*

------
https://chatgpt.com/codex/tasks/task_e_687b126fa0748332b0c4451cd55dd308