### PR TITLE
カレンダーUI更新

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -129,51 +129,33 @@ main {
 #calendar, .month {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 8px;
+  gap: 0;
   margin-bottom: var(--spacing);
 }
 .day-cell {
-  background: var(--card-bg);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  padding: 10px;
+  padding: 8px 0;
   text-align: center;
+  border-bottom: 1px solid var(--border);
   cursor: pointer;
-  box-shadow: 0 1px 3px var(--shadow);
-  transition: transform 0.1s, box-shadow 0.2s;
 }
 .day-cell.disabled {
-  /* 色が薄すぎるため、やや濃いめの --muted を使用 */
   color: var(--muted);
-  background: var(--bg);
   cursor: default;
-  box-shadow: none;
 }
-.day-cell.has-log {
-  border-color: #b22d35;
-  background: #b22d35;
-  color: #ffffff;
-}
-.day-cell.has-schedule {
-  border-color: var(--schedule-dark);
-  background: var(--schedule-light);
-  color: var(--schedule-dark);
-}
-.day-cell:hover:not(.disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px var(--shadow);
-}
-.day-cell.selected {
+.day-cell.selected .day-number {
   background: #ffffff;
   color: var(--primary-dark);
+  border-radius: 999px;
+  padding: 2px 6px;
   font-weight: 600;
-  border-color: var(--primary-dark);
-  box-shadow: 0 4px 8px var(--shadow);
 }
-
-/* 今日の日付を目立たせる */
-.day-cell.today {
-  box-shadow: 0 0 8px 2px #ffffff;
+.barbell {
+  font-size: 1rem;
+  display: block;
+  color: #b22d35;
+}
+.day-cell.today .day-number {
+  text-decoration: underline;
 }
 
 /* ログ詳細コンテナ */

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -24,12 +24,13 @@
             :key="'p'+day"
             :class="[
               'day-cell',
-              isLogOf(prevYear, prevMonthIndex, day) ? 'has-log' : (isScheduleOf(prevYear, prevMonthIndex, day) ? 'has-schedule' : 'disabled'),
-              isTodayOf(prevYear, prevMonthIndex, day) ? 'today' : ''
+              isTodayOf(prevYear, prevMonthIndex, day) ? 'today' : '',
+              isLogOf(prevYear, prevMonthIndex, day) ? 'has-log' : (isScheduleOf(prevYear, prevMonthIndex, day) ? 'has-schedule' : 'disabled')
             ]"
             @click="selectDateOf(prevYear, prevMonthIndex, day)"
           >
-            {{ day }}
+            <span class="day-number">{{ day }}</span>
+            <span v-if="isLogOf(prevYear, prevMonthIndex, day)" class="material-icons barbell">fitness_center</span>
           </div>
         </div>
         <div class="month" :key="viewYear + '-' + viewMonth">
@@ -39,13 +40,14 @@
             :key="'c'+day"
             :class="[
               'day-cell',
+              isToday(day) ? 'today' : '',
               isLog(day) ? 'has-log' : (isSchedule(day) ? 'has-schedule' : 'disabled'),
-              selectedDay === day ? 'selected' : '',
-              isToday(day) ? 'today' : ''
+              selectedDay === day ? 'selected' : ''
             ]"
             @click="selectDate(day)"
           >
-            {{ day }}
+            <span class="day-number">{{ day }}</span>
+            <span v-if="isLog(day)" class="material-icons barbell">fitness_center</span>
           </div>
         </div>
         <div class="month" :key="nextYear + '-' + nextMonthIndex">
@@ -55,12 +57,13 @@
             :key="'n'+day"
             :class="[
               'day-cell',
-              isLogOf(nextYear, nextMonthIndex, day) ? 'has-log' : (isScheduleOf(nextYear, nextMonthIndex, day) ? 'has-schedule' : 'disabled'),
-              isTodayOf(nextYear, nextMonthIndex, day) ? 'today' : ''
+              isTodayOf(nextYear, nextMonthIndex, day) ? 'today' : '',
+              isLogOf(nextYear, nextMonthIndex, day) ? 'has-log' : (isScheduleOf(nextYear, nextMonthIndex, day) ? 'has-schedule' : 'disabled')
             ]"
             @click="selectDateOf(nextYear, nextMonthIndex, day)"
           >
-            {{ day }}
+            <span class="day-number">{{ day }}</span>
+            <span v-if="isLogOf(nextYear, nextMonthIndex, day)" class="material-icons barbell">fitness_center</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要
- カレンダーのレイアウトを週区切りの水平線のみとし、日付間の線を撤廃
- 選択した日付は白丸表示に変更
- トレーニング済みの日付にはバーベルアイコンを表示

## テスト
- `npm test` は `vitest: not found` により失敗


------
https://chatgpt.com/codex/tasks/task_e_687b13e7c17c8332afb3b6986a5fda1f