### PR TITLE
予定アイコンをカレンダーに表示

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -154,6 +154,11 @@ main {
   display: block;
   color: #b22d35;
 }
+.schedule-icon {
+  font-size: 1rem;
+  display: block;
+  color: var(--schedule);
+}
 .day-cell.today .day-number {
   text-decoration: underline;
 }

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -31,6 +31,10 @@
           >
             <span class="day-number">{{ day }}</span>
             <span v-if="isLogOf(prevYear, prevMonthIndex, day)" class="material-icons barbell">fitness_center</span>
+            <span
+              v-else-if="isScheduleOf(prevYear, prevMonthIndex, day)"
+              class="material-icons schedule-icon"
+            >event</span>
           </div>
         </div>
         <div class="month" :key="viewYear + '-' + viewMonth">
@@ -48,6 +52,10 @@
           >
             <span class="day-number">{{ day }}</span>
             <span v-if="isLog(day)" class="material-icons barbell">fitness_center</span>
+            <span
+              v-else-if="isSchedule(day)"
+              class="material-icons schedule-icon"
+            >event</span>
           </div>
         </div>
         <div class="month" :key="nextYear + '-' + nextMonthIndex">
@@ -64,6 +72,10 @@
           >
             <span class="day-number">{{ day }}</span>
             <span v-if="isLogOf(nextYear, nextMonthIndex, day)" class="material-icons barbell">fitness_center</span>
+            <span
+              v-else-if="isScheduleOf(nextYear, nextMonthIndex, day)"
+              class="material-icons schedule-icon"
+            >event</span>
           </div>
         </div>
       </div>

--- a/tests/calendar.spec.js
+++ b/tests/calendar.spec.js
@@ -33,3 +33,18 @@ describe('Calendar firstDay (Monday start)', () => {
     expect(wrapper.vm.firstDay).toBe(3);
   });
 });
+
+describe('Schedule icon rendering', () => {
+  it('shows event icon when a schedule exists', async () => {
+    const wrapper = mount(Calendar, {
+      props: {
+        scheduleDates: ['2024-01-10'],
+        logDates: [],
+      },
+    });
+    wrapper.vm.viewYear = 2024;
+    wrapper.vm.viewMonth = 0; // January
+    await wrapper.vm.$nextTick();
+    expect(wrapper.html()).toContain('schedule-icon');
+  });
+});


### PR DESCRIPTION
## 概要
- カレンダーの各日付に予定がある場合、Material Icons の `event` を表示するようにしました
- 予定アイコン用のスタイル `.schedule-icon` を追加
- 新機能に対応したテストを追加

## テスト結果
- `npm install` はネットワーク制限により失敗
- `npm test` を実行すると `vitest: not found` で失敗


------
https://chatgpt.com/codex/tasks/task_e_687b158ee3888332a1d14e3d1a5214dd