### PR TITLE
最大値表示機能の追加

### DIFF
--- a/src/components/PastLogsModal.vue
+++ b/src/components/PastLogsModal.vue
@@ -2,7 +2,7 @@
   <div v-if="state.visible" class="modal-overlay" @click.self="close">
     <div class="modal">
       <header>
-        <h3>{{ state.lift }}</h3>
+        <h3>{{ header }}</h3>
         <button class="close-btn" @click="close">×</button>
       </header>
       <div v-for="(s, i) in state.sessions" :key="i" class="session">
@@ -38,6 +38,7 @@
 import { useLiftModal, hideLiftModal } from '../utils/liftModal'
 import { isAccessoryType } from '../utils/category'
 import { useRouter } from 'vue-router'
+import { computed } from 'vue'
 export default {
   name: 'PastLogsModal',
   setup() {
@@ -48,7 +49,14 @@ export default {
       hideLiftModal()
       router.push({ path: '/calendar', query: { date } })
     }
-    return { state, close, goDate, isAccessoryType }
+    const header = computed(() => {
+      if (state.maxWeight == null && state.max1RM == null) return state.lift
+      const parts = []
+      if (state.maxWeight != null) parts.push(`Max重量:${state.maxWeight}kg`)
+      if (state.max1RM != null) parts.push(`Max1RM:${state.max1RM}kg`)
+      return `${state.lift}(${parts.join('  ')})`
+    })
+    return { state, close, goDate, header, isAccessoryType }
   }
 }
 </script>

--- a/src/utils/liftModal.js
+++ b/src/utils/liftModal.js
@@ -3,11 +3,15 @@ import { reactive } from 'vue'
 const state = reactive({
   visible: false,
   lift: '',
-  sessions: []
+  sessions: [],
+  maxWeight: null,
+  max1RM: null
 })
 
 export function showLiftModal(lift, logs = []) {
   const sessions = []
+  let maxWeight = null
+  let max1RM = null
   for (const log of logs) {
     for (const sess of log.sessions || []) {
       if (sess.lift === lift) {
@@ -16,12 +20,23 @@ export function showLiftModal(lift, logs = []) {
           type: sess.type,
           sets: sess.sets
         })
+        for (const set of sess.sets || []) {
+          if (maxWeight == null || set.weight > maxWeight) {
+            maxWeight = set.weight
+          }
+          const oneRm = set['1RM']
+          if (oneRm != null && (max1RM == null || oneRm > max1RM)) {
+            max1RM = oneRm
+          }
+        }
       }
     }
   }
   sessions.sort((a, b) => b.date.localeCompare(a.date))
   state.lift = lift
   state.sessions = sessions
+  state.maxWeight = maxWeight
+  state.max1RM = max1RM
   state.visible = true
 }
 


### PR DESCRIPTION
## 概要
過去ログモーダルのヘッダーに対象種目の最大重量と最大1RMを表示できるようにしました。

## 変更点
- `liftModal` の状態に `maxWeight` と `max1RM` を追加し、`showLiftModal` 実行時に計算するよう修正
- `PastLogsModal` で計算結果を表示するための `header` 計算プロパティを追加

## 動作確認
- `npm test` を実行しましたが `vitest` が見つからずテストを実行できませんでした。


------
https://chatgpt.com/codex/tasks/task_e_687b180a5ba48332a5ee86e6960cc1a7