### PR TITLE
カレンダー初期表示の修正

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -167,6 +167,10 @@ export default {
       }
     }
   },
+  mounted() {
+    this.containerWidth = this.$refs.container.clientWidth;
+    this.currentTranslate = -this.containerWidth;
+  },
   methods: {
     formatYMD(y, m, d) {
       return `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`;


### PR DESCRIPTION
## 概要
カレンダーの初期表示で前月が表示されていたため、ログや予定のアイコンが読み込み直後に表示されませんでした。`mounted` フックで表示位置を中央（月表示部分）に合わせるよう修正しました。

## 変更点
- `Calendar.vue` に `mounted` フックを追加し、`containerWidth` を取得後 `currentTranslate` を `-containerWidth` に設定

## テスト
- `npm run test` を実行しましたが、依存パッケージが無いため `vitest: not found` と表示されました。

------
https://chatgpt.com/codex/tasks/task_e_687b29a40348833298ab288ee9358067