### PR TITLE
新しいガイドページ追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
           <router-link to="/calendar"><span class="material-icons">calendar_month</span></router-link>
           <router-link to="/list"><span class="material-icons">list</span></router-link>
           <router-link to="/guide"><span class="material-icons">help</span></router-link>
+          <router-link to="/visual-guide"><span class="material-icons">auto_awesome</span></router-link>
           <a href="#" @click.prevent="toggleUserMenu">
             <span class="material-icons">person</span>
           </a>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import CalendarView    from '../views/CalendarView.vue'
 import ListView        from '../views/ListView.vue'
 import RegisterView    from '../views/RegisterView.vue'
 import ChatGPTGuideView from '../views/ChatGPTGuideView.vue'
+import VisualChatGPTGuideView from '../views/VisualChatGPTGuideView.vue'
 
 const routes = [
   { path: '/',        redirect: '/calendar' },
@@ -10,6 +11,7 @@ const routes = [
   { path: '/list/:base?', component: ListView },
   { path: '/register', component: RegisterView },
   { path: '/guide', component: ChatGPTGuideView },
+  { path: '/visual-guide', component: VisualChatGPTGuideView },
 ]
 
 export default createRouter({

--- a/src/views/VisualChatGPTGuideView.vue
+++ b/src/views/VisualChatGPTGuideView.vue
@@ -1,0 +1,82 @@
+<template>
+  <section class="visual-guide">
+    <h2 class="title">ワクワクJSONガイド</h2>
+    <div
+      v-for="(step, i) in steps"
+      :key="i"
+      class="step"
+      ref="stepEls"
+    >
+      <span class="material-icons icon">{{ step.icon }}</span>
+      <h3>{{ step.title }}</h3>
+      <p>{{ step.text }}</p>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'VisualChatGPTGuideView',
+  data() {
+    return {
+      observer: null,
+      steps: [
+        { icon: 'file_copy', title: 'プロンプトをコピー', text: 'まずは既存のガイドからプロンプトをコピーします。' },
+        { icon: 'send', title: 'メニューを送信', text: '今日の種目や重量をChatGPTに伝えましょう。' },
+        { icon: 'chat', title: 'セット毎に報告', text: 'RPEや所感を送って会話を続けます。' },
+        { icon: 'code', title: 'JSON化を依頼', text: 'トレーニング終了後、ログをJSONで出力してもらいます。' },
+        { icon: 'save_alt', title: 'アプリに貼り付け', text: '生成されたJSONを登録ページに貼り付けて保存します。' }
+      ]
+    }
+  },
+  mounted() {
+    this.observer = new IntersectionObserver(entries => {
+      entries.forEach(e => {
+        if (e.isIntersecting) {
+          e.target.classList.add('show')
+        }
+      })
+    }, { threshold: 0.1 })
+
+    this.$refs.stepEls.forEach(el => this.observer.observe(el))
+  },
+  beforeUnmount() {
+    this.observer && this.observer.disconnect()
+  }
+}
+</script>
+
+<style scoped>
+.visual-guide {
+  padding: var(--spacing);
+}
+.title {
+  text-align: center;
+  margin-bottom: var(--spacing);
+}
+.step {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s, transform 0.6s;
+  background: var(--card-bg);
+  padding: var(--spacing);
+  margin-bottom: var(--spacing);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 8px var(--shadow);
+  text-align: center;
+}
+.step.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+.step .icon {
+  font-size: 3rem;
+  display: block;
+  margin-bottom: 8px;
+  animation: bounce 2s infinite;
+}
+@keyframes bounce {
+  0%,100% { transform: translateY(0); }
+  50% { transform: translateY(-8px); }
+}
+</style>


### PR DESCRIPTION
## 概要

ChatGPT から JSON を出力させる手順をより視覚的に学べる新ページ `VisualChatGPTGuideView.vue` を追加しました。ナビゲーションにリンクを設け、ルーターへも登録しています。

## 主な変更点
- 新規ビュー `VisualChatGPTGuideView.vue` を作成
- ルーティングに `/visual-guide` を追加
- ヘッダーにアイコン付きリンクを追加

## テスト
- `npm run test` を実行しましたが、依存パッケージがないため `vitest` が見つからず失敗しました。

------
https://chatgpt.com/codex/tasks/task_e_687ca4ace7e483329d74eeb29a0440eb