### PR TITLE
サイト利用ガイドの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 https://moriken-forest.github.io/training-log-spa/#/calendar
 
+サイトの操作方法は以下のページにまとめています。
+
+https://moriken-forest.github.io/training-log-spa/#/usage
+
 
 This repository manages daily training logs using GitHub Issues.
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@
           <router-link to="/list"><span class="material-icons">list</span></router-link>
           <router-link to="/guide"><span class="material-icons">help</span></router-link>
           <router-link to="/visual-guide"><span class="material-icons">auto_awesome</span></router-link>
+          <router-link to="/usage"><span class="material-icons">menu_book</span></router-link>
           <a href="#" @click.prevent="toggleUserMenu">
             <span class="material-icons">person</span>
           </a>

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -630,6 +630,38 @@ main {
   transform: translateY(1px);
 }
 
+/* 使い方ガイド */
+#usage-section {
+  max-width: 600px;
+  margin: 0 auto;
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  padding: var(--spacing);
+  box-shadow: 0 2px 6px var(--shadow);
+}
+
+#usage-section h2 {
+  margin-bottom: var(--spacing);
+  font-size: 1.5rem;
+  text-align: center;
+  color: var(--primary-dark);
+}
+
+#usage-section h3 {
+  margin-top: var(--spacing);
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+}
+
+#usage-section ul {
+  margin-left: 1em;
+  padding-left: 1em;
+  margin-bottom: var(--spacing);
+}
+#usage-section li {
+  margin-bottom: 4px;
+}
+
 /* トグルスイッチ */
 .toggle-wrapper {
   display: flex;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import ListView        from '../views/ListView.vue'
 import RegisterView    from '../views/RegisterView.vue'
 import ChatGPTGuideView from '../views/ChatGPTGuideView.vue'
 import VisualChatGPTGuideView from '../views/VisualChatGPTGuideView.vue'
+import UsageGuideView from '../views/UsageGuideView.vue'
 
 const routes = [
   { path: '/',        redirect: '/calendar' },
@@ -12,6 +13,7 @@ const routes = [
   { path: '/register', component: RegisterView },
   { path: '/guide', component: ChatGPTGuideView },
   { path: '/visual-guide', component: VisualChatGPTGuideView },
+  { path: '/usage', component: UsageGuideView },
 ]
 
 export default createRouter({

--- a/src/views/UsageGuideView.vue
+++ b/src/views/UsageGuideView.vue
@@ -1,0 +1,30 @@
+<template>
+  <section id="usage-section">
+    <h2>サイトの使い方</h2>
+    <p>PowerLog の機能と操作方法をまとめています。</p>
+    <h3>1. 基本操作</h3>
+    <ul>
+      <li>GitHub Issues から <strong>Training Log</strong> テンプレートを使ってログを登録します。</li>
+      <li>削除したい場合は <code>delete-training-log</code> ラベルを付け、ユーザー名と日付を記載した issue を作成します。</li>
+      <li>登録された JSON は <code>public/logs/&lt;user&gt;</code> に保存され、カレンダーや一覧に反映されます。</li>
+    </ul>
+    <h3>2. 各画面の概要</h3>
+    <ul>
+      <li><strong>カレンダー</strong> : 日付ごとのログとスケジュールを確認できます。クリックすると詳細を表示します。</li>
+      <li><strong>一覧</strong> : ログやスケジュールを表形式で閲覧できます。カテゴリや件数を切り替え可能です。</li>
+      <li><strong>登録</strong> : ChatGPT などで作成した JSON を貼り付けてローカルに保存します。</li>
+      <li><strong>ガイド</strong> : ChatGPT を使った記録方法を説明しています。</li>
+    </ul>
+    <h3>3. ユーザー切り替えとキャッシュ</h3>
+    <ul>
+      <li>ヘッダーの人物アイコンからユーザーを選択できます。</li>
+      <li>更新が反映されない場合はリフレッシュアイコンでキャッシュを削除してください。</li>
+    </ul>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'UsageGuideView'
+}
+</script>

--- a/tests/usage.spec.js
+++ b/tests/usage.spec.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import UsageGuideView from '../src/views/UsageGuideView.vue'
+
+describe('UsageGuideView', () => {
+  it('renders heading', () => {
+    const wrapper = mount(UsageGuideView)
+    expect(wrapper.text()).toContain('サイトの使い方')
+  })
+})


### PR DESCRIPTION
## 概要
- 使い方をまとめた `UsageGuideView` を追加
- ルーターとナビゲーションに `/usage` を追加
- スタイルシートに使い方ガイド用スタイルを追加
- README にガイドへのリンクを追記
- テストを1件追加

## テスト結果
- `npm install` (失敗)
- `npm run test` (実行不可: vitest 未インストール)


------
https://chatgpt.com/codex/tasks/task_e_687cb83eb89c8332ba6f1289b0a76391